### PR TITLE
workflow test

### DIFF
--- a/.github/workflows/hb34pack.yml
+++ b/.github/workflows/hb34pack.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
 
     - name: mingw 7.3
-      uses: https://github.com/dawidd6/action-download-artifact
+      uses: dawidd6/action-download-artifact
       with:
          workflow: mingw_0703.yml
          workflow_conclusion: success
@@ -32,7 +32,7 @@ jobs:
          repo: JoseQuintas/addons
 
     - name: harbour 3.4
-      uses: https://github.com/dawidd6/action-download-artifact
+      uses: dawidd6/action-download-artifact
       with:
          workflow: hb34_0703.yml
          workflow_conclusion: success

--- a/.github/workflows/hb34pack.yml
+++ b/.github/workflows/hb34pack.yml
@@ -1,6 +1,7 @@
 #
 # use: JoseQuintas/addons/mingw_0703
 # use: JoseQuintas/addons/hb34_0703
+# 2022.04.25 (to force a new write)
 
 name: hb34pack
 

--- a/.github/workflows/hb34pack.yml
+++ b/.github/workflows/hb34pack.yml
@@ -1,0 +1,94 @@
+#
+# use: JoseQuintas/addons/mingw_0703
+# use: JoseQuintas/addons/hb34_0703
+
+name: hb34pack
+
+on:
+#  push:
+#  schedule:
+#   - cron: "45 5 2 * *"
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'hb34pack'
+        default: 'hb34pack'
+        required: true
+
+jobs:
+
+  Build:
+    runs-on: windows-latest
+    steps:
+
+    - name: mingw 7.3
+      uses: JoseQuintas/action-download-artifact@v2
+      with:
+         workflow: mingw_0703.yml
+         workflow_conclusion: success
+         name: mingw_0703
+         path: c:\temp
+         repo: JoseQuintas/addons
+
+    - name: harbour 3.4
+      uses: JoseQuintas/action-download-artifact@v2
+      with:
+         workflow: hb34_0703.yml
+         workflow_conclusion: success
+         name: hb34_0703
+         path: c:\temp
+         repo: JoseQuintas/addons
+
+    - name: Load Source Code
+      env:
+         REPO_CORE:       https://github.com/oohg/core
+         REPO_SAMPLES:    https://github.com/oohg/samples
+         REPO_DOC:        https://github.com/oohg/doc
+         PATH_CORE:       c:\temp\oohg
+         PATH_SAMPLES:    c:\temp\oohg\samples
+         PATH_DOC:        c:\temp\oohg\doc
+      run: |
+         c:
+         git clone $env:REPO_CORE       $env:PATH_CORE     --depth 1
+         git clone $env:REPO_SAMPLES    $env:PATH_SAMPLES  --depth 1
+         git clone $env:REPO_DOC        $env:PATH_DOC      --depth 1
+
+    - name: Unzip
+      env:
+         PATH: c:\program files\7-zip
+      run: |
+         c:
+         7z x -y c:\temp\hb34_0703.7z -oc:\temp\oohg\harbour
+         7z x -y c:\temp\mingw_0703.7z -oc:\temp\oohg\mingw
+
+    - name: Build All
+      env:
+         HB_BUILD_STRIP: all
+         HB_COMPILER: mingw
+         HB_INSTALL_PREFIX: c:\temp\oohg\harbour
+         HBMK_CMD: -workdir=c:\temp -q -quiet
+         PATH: c:\temp\oohg\mingw\mingw64\bin;c:\temp\oohg\harbour\bin
+      run: |
+         c:
+         cd c:\temp\oohg\source
+         hbmk2 oohg.hbp
+         hbmk2 oohg.hbp -comp=mingw64
+         hbmk2 hbprinter.hbp
+         hbmk2 hbprinter.hbp -comp=mingw64
+         hbmk2 miniprint.hbp
+         hbmk2 miniprint.hbp -comp=mingw64
+         hbmk2 winprint.hbp
+         hbmk2 winprint.hbp -comp=mingw64
+
+    - name: Zip
+      env:
+         PATH: c:\program files\7-zip
+      run: |
+         c:
+         7z a -r c:\temp\hb34pack.7z c:\temp\oohg\*.* -xr'!.git' -xr'!.github' -xr'!.hbmk'
+
+    - name: Save
+      uses: actions/upload-artifact@v2
+      with:
+         name: harbour34
+         path: c:\temp\hb34pack.7z

--- a/.github/workflows/hb34pack.yml
+++ b/.github/workflows/hb34pack.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
 
     - name: mingw 7.3
-      uses: JoseQuintas/action-download-artifact@v2
+      uses: https://github.com/dawidd6/action-download-artifact
       with:
          workflow: mingw_0703.yml
          workflow_conclusion: success
@@ -32,7 +32,7 @@ jobs:
          repo: JoseQuintas/addons
 
     - name: harbour 3.4
-      uses: JoseQuintas/action-download-artifact@v2
+      uses: https://github.com/dawidd6/action-download-artifact
       with:
          workflow: hb34_0703.yml
          workflow_conclusion: success


### PR DESCRIPTION
Only a draft.
Need to save official Harbour/XHarbour on any repository and/or create a workflow result like me.
Need to add full configuration to compile.
Workflow runs but need extra configuration - hbmk2 do not need them, but oohg have bats to do this.
Note: only manual execution is available. You can remove # from workflow, to run on each commit and/or monthly automatically, Can use the 3 way at same time.
As a first test, you can merge, go to github distros page, actions, select workflow and select run this workflow, and click to see details during generation, or click on final, on error message. After this, you can see the zip file attached to workflow.
No change on repository, nothing is saved on repository, except this file with workflow.